### PR TITLE
Patched for tensorflow 1.11

### DIFF
--- a/jupyter_tensorboard/tensorboard_manager.py
+++ b/jupyter_tensorboard/tensorboard_manager.py
@@ -22,6 +22,7 @@ try:
 
         def create_tb_app(logdir, reload_interval, purge_orphaned_data):
             argv = [
+                        "",
                         "--logdir", logdir,
                         "--reload_interval", str(reload_interval),
                         "--purge_orphaned_data", str(purge_orphaned_data),

--- a/jupyter_tensorboard/tensorboard_manager.py
+++ b/jupyter_tensorboard/tensorboard_manager.py
@@ -15,8 +15,8 @@ from tensorboard.backend import application   # noqa
 try:
     # Tensorboard 0.4.x above series
     from tensorboard import default
-    if hasattr(default, 'PLUGIN_LOADERS'):
-        # Tensorflow 1.10 series
+    if hasattr(default, 'PLUGIN_LOADERS') or hasattr(default, '_PLUGINS'):
+        # Tensorflow 1.10 or above series
         logging.debug("Tensorboard 1.10 or above series detected")
         from tensorboard import program
 
@@ -26,9 +26,7 @@ try:
                         "--reload_interval", str(reload_interval),
                         "--purge_orphaned_data", str(purge_orphaned_data),
                    ]
-            tensorboard = program.TensorBoard(
-                default.PLUGIN_LOADERS,
-                default.get_assets_zip_provider())
+            tensorboard = program.TensorBoard()
             tensorboard.configure(argv)
             return application.standard_tensorboard_wsgi(
                 tensorboard.flags,


### PR DESCRIPTION
Hi,

I tried to use the plugin with the last versions of tensorflow (1.11) and jupyter but it would give an error. 
I've noticed that it wasn't recognizing the 1.11 version and it was still using the old api while creating the tensorboard app. I've fixed the problem and tested it.

Davide