### PR TITLE
Restrict the tensorboard package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     ]],
     install_requires=[
         'notebook>=5.0',
+        'tensorboard>=1.3.0,<1.12.0'
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Fix issue 37 by restrict tensorboard version<1.12.0 as tensorboard>=1.12.0 incompatible with jupyter_tensoraboard.
Detail see: #37  