### PR TITLE
Allow custom logdir specification

### DIFF
--- a/jupyter_tensorboard/api_handlers.py
+++ b/jupyter_tensorboard/api_handlers.py
@@ -10,7 +10,11 @@ from .handlers import notebook_dir
 
 
 def _trim_notebook_dir(dir):
-    return os.path.join("<notebook_dir>", os.path.relpath(dir, notebook_dir))
+    if not dir.startswith("/"):
+        return os.path.join(
+            "<notebook_dir>", os.path.relpath(dir, notebook_dir)
+        )
+    return dir
 
 
 class TbRootHandler(APIHandler):


### PR DESCRIPTION
Hey,

First of all, thanks for making this project. I've found it really useful.

I have a use case where I want to specify a logging directory for Tensorboard that is outside of the current Jupyter root directory. I wasn't able to find a way to do this with the existing UI, so I made a fork and added something myself. I thought I would make a pull request in case you think it might be useful to other people.

Here's how it works. Now from the "New" menu in Jupyter you can select either Current Directory or Custom Directory:

![image](https://user-images.githubusercontent.com/15220906/56725499-df1a7180-6744-11e9-81ac-72435d4855d0.png)

Selecting Custom Directory brings up a modal with a text field into which any path can be entered

![image](https://user-images.githubusercontent.com/15220906/56725695-40dadb80-6745-11e9-8881-e7f0171d7e26.png)

This creates the Tensorboard instance with the supplied path being used as the logging directory.

The main thing missing at the moment I would say is that it doesn't do any validation on the filepath supplied by the user, so for example you can create a Tensorboard instance that uses a non-existent directory as its logging directory (maybe that's useful if the directory gets created during model training or something?). 

Other things: maybe rather than the dropleft submenu, there should just be another section to the original dropdown titled "Tensorboard", like there currently is "Notebooks" and "Other". Also I didn't add any tests, but it's probably worth doing so. Happy to take guidance on that.

Happy for you to say whether you think any of those are important to add or whether they can wait to a future update.



Anyway, let me know if you think this is something that's worth adding.