### PR TITLE
Support hparams plugin via Tensorboard POST api handler.

### DIFF
--- a/jupyter_tensorboard/handlers.py
+++ b/jupyter_tensorboard/handlers.py
@@ -107,12 +107,16 @@ class TensorboardHandler(IPythonHandler):
             return super(TensorboardHandler, self).check_xsrf_cookie()
         except web.HTTPError:
             if self.request.method in {"GET", "POST", "HEAD"}:
-                # Consider Referer a sufficient cross-origin check for GET requests
-                # Extended to post for Tensorboard API
+                # Consider Referer a sufficient cross-origin check for GET
+                # requests, mirrors logic in IPythonHandler.check_xsrf_cookie.
+                # Extended to POST for Tensorboard API.
                 if not self.check_referer():
                     referer = self.request.headers.get("Referer")
                     if referer:
-                        msg = "Blocking Cross Origin request from {}.".format(referer)
+                        msg = (
+                            "Blocking Cross Origin request from {}."
+                            .format(referer)
+                        )
                     else:
                         msg = "Blocking request from unknown origin"
                     raise web.HTTPError(403, msg)

--- a/jupyter_tensorboard/handlers.py
+++ b/jupyter_tensorboard/handlers.py
@@ -91,6 +91,34 @@ class TensorboardHandler(IPythonHandler):
         else:
             raise web.HTTPError(404)
 
+    def check_xsrf_cookie(self):
+        """Expand xsrf check exception for POST requests.
+
+        Expand xsrf_cookie exceptions, normally only applied to GET and HEAD
+        requests, to POST requests for tensorboard api.
+
+        Provides support for hparams plugin, which uses POST to retrieve
+        experiment information but can't be trivially extended to include xsrf
+        information in these POST requests.
+
+        """
+
+        try:
+            return super(TensorboardHandler, self).check_xsrf_cookie()
+        except web.HTTPError:
+            if self.request.method in {"GET", "POST", "HEAD"}:
+                # Consider Referer a sufficient cross-origin check for GET requests
+                # Extended to post for Tensorboard API
+                if not self.check_referer():
+                    referer = self.request.headers.get("Referer")
+                    if referer:
+                        msg = "Blocking Cross Origin request from {}.".format(referer)
+                    else:
+                        msg = "Blocking request from unknown origin"
+                    raise web.HTTPError(403, msg)
+            else:
+                raise
+
 
 class TensorboardErrorHandler(IPythonHandler):
     pass

--- a/jupyter_tensorboard/handlers.py
+++ b/jupyter_tensorboard/handlers.py
@@ -70,6 +70,27 @@ class TensorboardHandler(IPythonHandler):
         else:
             raise web.HTTPError(404)
 
+    @web.authenticated
+    def post(self, name, path):
+
+        if path == "":
+            uri = self.request.path + "/"
+            if self.request.query:
+                uri += "?" + self.request.query
+            self.redirect(uri, permanent=True)
+            return
+
+        self.request.path = (
+            path if self.request.query
+            else "%s?%s" % (path, self.request.query))
+
+        manager = self.settings["tensorboard_manager"]
+        if name in manager:
+            tb_app = manager[name].tb_app
+            WSGIContainer(tb_app)(self.request)
+        else:
+            raise web.HTTPError(404)
+
 
 class TensorboardErrorHandler(IPythonHandler):
     pass


### PR DESCRIPTION
The Tensorboard hparams plugin, included in tensorboard 1.14+,
uses POST requests to access experiment information. The 0.1.10
of jupyter_tensorboard only provides a GET handler, breaking the
hparams Tensorboard view.

Expand TensorboardHandler to include both GET and POST actions 
and extended xsrf_cookie exceptions, normally only applied to GET 
and HEAD requests in the IPythonHandler, to POST requests in
TensorboardHandler.

Provides support for hparams plugin, which uses POST to retrieve
experiment information but can't be trivially extended to include xsrf
information in these POST requests. Mirrors existing IPythonHandler
behavior, falling back to Referer header rather than form parameters.